### PR TITLE
Fix setting tab title so it actually works in iTerm 2

### DIFF
--- a/consular-iterm.gemspec
+++ b/consular-iterm.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'consular'
   s.add_dependency 'rb-appscript'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'mocha'
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"

--- a/spec/iterm_spec.rb
+++ b/spec/iterm_spec.rb
@@ -23,9 +23,16 @@ describe Consular::ITerm do
     assert_equal ['ls'],       @core.prepend_befores(['ls'])
   end
 
-  it "should set .set_title" do
-    assert_equal ["PS1=\"$PS1\\[\\e]2;hey\\a\\]\"",'ls'], @core.set_title('hey', ['ls'])
-    assert_equal ['ls'],                                  @core.set_title(nil,   ['ls'])
+  it "should set the title of the tab if one given" do
+    (name = Object.new).expects(:set)
+    (tab = Object.new).stubs(:name).returns(name)
+    @core.set_title('the title', tab)
+  end
+
+  it "should not bother setting the tab title if not one given" do
+    (name = Object.new).expects(:set).never
+    (tab = Object.new).stubs(:name).returns(name)
+    @core.set_title(nil, tab)
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 gem 'minitest'
 require 'minitest/autorun'
+require 'mocha'
 require File.expand_path('../../lib/consular/iterm', __FILE__)
 
 


### PR DESCRIPTION
As I reported in terminitor, [the PS1 trick does not work in iTerm for setting tab titles](https://github.com/achiu/terminitor/issues/89). You have to call .name.set(...) on the tab instance itself. This patch should make it work again.

Only issue with this is that it changes the signature of #set_title. Is that okay?
