### PR TITLE
Update consular-iterm dependencies to work with Ruby 2.2

### DIFF
--- a/consular-iterm.gemspec
+++ b/consular-iterm.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'consular'
   s.add_dependency 'rb-scpt'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'minitest-reporters'
   s.add_development_dependency 'mocha'
 
   # specify any dependencies here; for example:

--- a/consular-iterm.gemspec
+++ b/consular-iterm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'consular'
-  s.add_dependency 'rb-appscript'
+  s.add_dependency 'rb-scpt'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
 

--- a/lib/consular/iterm.rb
+++ b/lib/consular/iterm.rb
@@ -1,5 +1,5 @@
 require 'consular'
-require 'appscript'
+require 'rb-scpt'
 require File.expand_path('../iterm_dsl', __FILE__)
 
 module Consular

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 gem 'minitest'
 require 'minitest/autorun'
+require 'minitest/reporters'
 require 'mocha'
 require File.expand_path('../../lib/consular/iterm', __FILE__)
 
@@ -31,4 +32,6 @@ class ColoredIO
   end
 end
 
-MiniTest::Unit.output = ColoredIO.new(MiniTest::Unit.output)
+Minitest::Reporters.use! [
+  Minitest::Reporters::DefaultReporter.new(color: true)
+]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ gem 'minitest'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'mocha'
+require 'mocha/setup'
 require File.expand_path('../../lib/consular/iterm', __FILE__)
 
 


### PR DESCRIPTION
This addresses https://github.com/achiu/consular-iterm/issues/10, though it may break backwards compatibility with older versions of Ruby.

rb-appscript has been somewhat abandoned on Rubygems.  Mattneub [forked it and its sister projects](https://github.com/achiu/consular-iterm/issues/10) (objc, python, macruby).  There were some updates made, including one that addressed the appscript install problem (issue 10).  Unfortunately, Matt never took over the Rubygems project, so consular-iterm never benefitted from the update.

Brendan Thompson made a [ruby-only fork](https://github.com/BrendanThompson/rb-scpt) and added the gem to Rubygems.  His fork is what this PR references instead of rb-appscript.

It looks like Matt has been looking to hand off maintenance of appscript, so [I've suggested handing off the Ruby portion to Brendan](https://github.com/mattneub/appscript/issues/12).  You might want to hold off on merging this PR until that's resolved, but at least people who want Consular on Ruby 2.2 can reference this PR-branch.

Moving forward, the discussion of [Brendan's similar issue on jira-omnifocus](https://github.com/devondragon/jira-omnifocus/issues/13) suggests that OS X Yosemite and onward provide js bindings for old Apple Script interfaces.  Maybe something to look into?