### PR TITLE
Fixed support for iTerm 3.0.10

### DIFF
--- a/lib/consular/iterm.rb
+++ b/lib/consular/iterm.rb
@@ -38,7 +38,7 @@ module Consular
     # @api public
     def initialize(path)
       super
-      @terminal = app('iTerm')
+      @terminal = app('iTerm 2')
     end
 
     # Method called by runner to Execute Termfile setup.
@@ -303,7 +303,7 @@ module Consular
     #
     # @api public
     def iterm_menu
-      _process = app("System Events").processes["iTerm"]
+      _process = app("System Events").processes["iTerm2"]
       _process.menu_bars.first
     end
 


### PR DESCRIPTION
Hi,

I've made a small change to get consular-iterm running with iTerm 3.0.10 on OSX 10.10.5 and ruby 2.2.3.

All tests passed but I think this change will break the compatibility with older iTerm versions.
