### PR TITLE
Fix for #13

### DIFF
--- a/lib/consular/iterm.rb
+++ b/lib/consular/iterm.rb
@@ -38,7 +38,7 @@ module Consular
     # @api public
     def initialize(path)
       super
-      @terminal = app('iTerm 2')
+      @terminal = app('iTerm')
     end
 
     # Method called by runner to Execute Termfile setup.

--- a/lib/consular/iterm.rb
+++ b/lib/consular/iterm.rb
@@ -38,7 +38,7 @@ module Consular
     # @api public
     def initialize(path)
       super
-      @terminal = app('iTerm')
+      @terminal = app('iTerm 2')
     end
 
     # Method called by runner to Execute Termfile setup.
@@ -303,7 +303,7 @@ module Consular
     #
     # @api public
     def iterm_menu
-      _process = app("System Events").processes["iTerm"]
+      _process = app("System Events").processes["iTerm2"]
       _process.menu_bars.first
     end
 


### PR DESCRIPTION
This extends pr #15 and removes a line that causes an error when trying to run `consular start`.

To test builds, I ran the following script as `test.term` via `rake install && consular start test`:

```markdown
# Test setup with panes

setup 'cd ~'

before { run 'cd ~'}

window do
  pane "gitx"    # first pane
    pane do      # second pane level => horizontal split
      run "echo 'this is a pane'"
    end
  pane 'ls'      # first pane level => vertical split
end
```

Prior to the commit 59f986772d866ad7deadf9108dbde16137239705, running the script above would fail with `\`rescue in _find_app': Application "[\"iTerm 2.app\"]" not found. (FindApp::ApplicationNotFoundError)` during `consular start test`.

I think with this, @achiu we can close out #13.
